### PR TITLE
Promises Support

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -8,16 +8,17 @@ module.exports = (opts) ->
 
   class RootsNetlify
     constructor: (@roots) ->
-      opts.redirects ?= {}
-      opts.rewrites  ?= {}
-      opts.headers   ?= {}
       @util = new RootsUtil(@roots)
 
     setup: ->
-      W.all([write_headers.call(@), write_redirects.call(@)])
+      W(opts).with(@)
+        .then (opts) ->
+          @opts = _.defaults(opts, {redirects: {}, rewrites: {}, headers: {}})
+        .then ->
+          W.all([write_headers.call(@), write_redirects.call(@)])
 
     write_headers = ->
-      res = _.reduce opts.headers, (str, conf, path) ->
+      res = _.reduce @opts.headers, (str, conf, path) ->
         str += "#{path}\n"
         str += "  #{k}: #{v}\n" for k, v of conf
         return str
@@ -25,11 +26,11 @@ module.exports = (opts) ->
       @util.write '_headers', res
 
     write_redirects = ->
-      redirects = _.pick(opts.redirects, codes)
+      redirects = _.pick(@opts.redirects, codes)
       redirects['200'] ?= {}
       redirects['301'] ?= {}
-      _.merge(redirects['200'], opts.rewrites)
-      _.merge(redirects['301'], _.omit(opts.redirects, codes))
+      _.merge(redirects['200'], @opts.rewrites)
+      _.merge(redirects['301'], _.omit(@opts.redirects, codes))
 
       res = _.reduce redirects, (str, conf, code) ->
         for k, v of conf

--- a/readme.md
+++ b/readme.md
@@ -53,25 +53,20 @@ Redirects added to the `redirects` object return a status code of `301` while th
 
 ### Promises
 
-Instead of passing the regular options object into the extension, you can also pass a promise for an options object, in case you need to perform any asynchronous work (such as making an http request) before configuring roots-netlify.
+Instead of passing the regular options object into the extension, you can also pass a promise for an options object in case you need to perform any asynchronous work (such as loading a file or making an http request) before configuring roots-netlify.
+
 
 ```coffee
-W = require 'when'
+fs     = require 'fs'
+nodefn = require 'when/node'
+yaml   = require 'js-yaml'
 
-opts =
-  redirects:
-    '/news': '/blog'
-    '/news/:year/:month:/:date/:slug': '/blog/:year/:month/:date/:story_id'
-  rewrites:
-    '/*': '/index.html'
-  headers:
-    '/*':
-      'X-Frame-Options': 'DENY'
-      'X-XSS-Protection': '1; mode=block'
+config = nodefn.call(fs.readFile, 'config.yaml')
+  .then (contents) -> yaml.safeLoad(contents)
 
 module.exports =
   extensions: [
-    netlify(W.resolve(opts))
+    netlify(config)
   ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,30 @@ Read the Netlify documentation on [redirects](https://docs.netlify.com/redirects
 
 Redirects added to the `redirects` object return a status code of `301` while those added to the `rewrites` object will return `200` (a rewrite). Netlify also [supports](https://docs.netlify.com/redirects#http-status-codes) two other status codes: `302` and `404`. In order to configure your redirects for these, add a `302` or `404` key to `redirects` and nest your configuration object there (see example above).
 
+### Promises
+
+Instead of passing the regular options object into the extension, you can also pass a promise for an options object, in case you need to perform any asynchronous work (such as making an http request) before configuring roots-netlify.
+
+```coffee
+W = require 'when'
+
+opts =
+  redirects:
+    '/news': '/blog'
+    '/news/:year/:month:/:date/:slug': '/blog/:year/:month/:date/:story_id'
+  rewrites:
+    '/*': '/index.html'
+  headers:
+    '/*':
+      'X-Frame-Options': 'DENY'
+      'X-XSS-Protection': '1; mode=block'
+
+module.exports =
+  extensions: [
+    netlify(W.resolve(opts))
+  ]
+```
+
 ### License & Contributing
 
 - Details on the license [can be found here](LICENSE.md)

--- a/test/fixtures/promises/app.coffee
+++ b/test/fixtures/promises/app.coffee
@@ -1,0 +1,27 @@
+netlify = require '../../..'
+W       = require 'when'
+
+config =
+  redirects:
+    '/news': '/blog'
+    '/news/:year/:month:/:date/:slug': '/blog/:year/:month/:date/:story_id'
+    '/news/*': '/blog/:splat'
+    '302':
+      '/temp_redirect': '/'
+    '404':
+      '/ecommerce': '/closed'
+  rewrites:
+    '/*': '/index.html'
+  headers:
+    '/protected/path':
+      'Cache-Control': 'max-age: 3000'
+      'Basic-Auth': 'username:password'
+    '/*':
+      'X-Frame-Options': 'DENY'
+      'X-XSS-Protection': '1; mode=block'
+
+module.exports =
+  ignores: ["**/.DS_Store"]
+  extensions: [
+    netlify(W.resolve(config))
+  ]

--- a/test/fixtures/promises/expected/_headers
+++ b/test/fixtures/promises/expected/_headers
@@ -1,0 +1,6 @@
+/protected/path
+  Cache-Control: max-age: 3000
+  Basic-Auth: username:password
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block

--- a/test/fixtures/promises/expected/_redirects
+++ b/test/fixtures/promises/expected/_redirects
@@ -1,0 +1,6 @@
+/* /index.html 200
+/news /blog 301
+/news/:year/:month:/:date/:slug /blog/:year/:month/:date/:story_id 301
+/news/* /blog/:splat 301
+/temp_redirect / 302
+/ecommerce /closed 404

--- a/test/fixtures/promises/index.jade
+++ b/test/fixtures/promises/index.jade
@@ -1,0 +1,1 @@
+p hello world

--- a/test/fixtures/promises/package.json
+++ b/test/fixtures/promises/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*",
+    "when": "^3.6.4"
+  }
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -37,3 +37,16 @@ describe 'basic setup', ->
     compiled = path.join(@public, '_redirects')
     expected = path.join(@public, 'expected', '_redirects')
     h.file.matches_file(compiled, expected).should.be.true
+
+describe 'promises support', ->
+  before (done) -> compile_fixture.call(@, 'promises', -> done())
+
+  it 'compiles the headers config file using promises grep', ->
+    compiled = path.join(@public, '_headers')
+    expected = path.join(@public, 'expected', '_headers')
+    h.file.matches_file(compiled, expected).should.be.true
+
+  it 'compiles the redirects config file using promises', ->
+    compiled = path.join(@public, '_redirects')
+    expected = path.join(@public, 'expected', '_redirects')
+    h.file.matches_file(compiled, expected).should.be.true


### PR DESCRIPTION
This adds support for passing in a promise that returns the netfliy options hash. This is useful if you need to perform any async work (http requests, load a file etc..) in order to properly configure your netlify options hash.